### PR TITLE
Feature/53 feature prevent accidental use of parent setters

### DIFF
--- a/StylableWinFormsControls/StylableWinFormsControls.Example/FrmDefault.Designer.cs
+++ b/StylableWinFormsControls/StylableWinFormsControls.Example/FrmDefault.Designer.cs
@@ -236,7 +236,7 @@ namespace StylableWinFormsControls.Example
             stylableTextBox1.BorderColor = Color.Blue;
             stylableTextBox1.BorderStyle = BorderStyle.None;
             stylableTextBox1.DelayedTextChangedTimeout = 900;
-            stylableTextBox1.ForeColor = Color.Gray;
+            stylableTextBox1.HintForeColor = Color.Gray;
             stylableTextBox1.Hint = "Hello, my name is ...";
             stylableTextBox1.HintForeColor = Color.Gray;
             stylableTextBox1.IsDelayActive = true;

--- a/StylableWinFormsControls/StylableWinFormsControls/Controls/StylableTextBox.cs
+++ b/StylableWinFormsControls/StylableWinFormsControls/Controls/StylableTextBox.cs
@@ -172,9 +172,7 @@ public class StylableTextBox : TextBox
         {
             //The text change either comes from the user or the application setting a default value
             IsHintActive = false;
-#pragma warning disable CS0618 //Obsolete
             ForeColor = TextForeColor;
-#pragma warning restore CS0618 //Obsolete
         }
     }
 
@@ -184,9 +182,7 @@ public class StylableTextBox : TextBox
         {
             IsHintActive = true;
             _hintRefresh = true;
-#pragma warning disable CS0618 //Obsolete
             ForeColor = HintForeColor;
-#pragma warning restore CS0618 //Obsolete
             base.Text = Hint;
             _hintRefresh = false;
             if (_hintActiveChanged is not null)
@@ -203,9 +199,7 @@ public class StylableTextBox : TextBox
         if (IsHintActive && !string.IsNullOrEmpty(base.Text))
         {
             IsHintActive = false;
-#pragma warning disable CS0618 //Obsolete
             ForeColor = TextForeColor;
-#pragma warning restore CS0618 //Obsolete
             _hintRefresh = true;
 
             base.Text = string.Empty;

--- a/StylableWinFormsControls/StylableWinFormsControls/Controls/StylableTextBox.cs
+++ b/StylableWinFormsControls/StylableWinFormsControls/Controls/StylableTextBox.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Reflection;
 
 namespace StylableWinFormsControls;
 
@@ -52,12 +53,29 @@ public class StylableTextBox : TextBox
     /// We are hiding this as it is only the current color of the text.
     /// Use <see cref="TextForeColor"/> to set the color of the text or <see cref="HintForeColor"/> for the hint.
     /// </summary>
+    /// <exception cref="InvalidOperationException">thrown when called from outside this lib</exception>
     [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("Use TextForeColor or HintForeColor instead")]
+    [InternalUseOnly("Use TextForeColor or HintForeColor instead")]
     public new Color ForeColor
     {
-        get => base.ForeColor;
-        set => base.ForeColor = value;
+        get
+        {
+            if (StylableWinFormsControlsSettings.DEFAULT.IsErrorHandlingFail() && Assembly.GetCallingAssembly() != GetType().Assembly)
+            {
+                throw new InvalidOperationException("Do not call ForeColor. Use other available properties HintForeColor/TextForeColor instead");
+            }
+
+            return base.ForeColor;
+        }
+        set
+        {
+            if (StylableWinFormsControlsSettings.DEFAULT.IsErrorHandlingFail() && Assembly.GetCallingAssembly() != GetType().Assembly)
+            {
+                throw new InvalidOperationException("Do not call ForeColor. Use other available properties HintForeColor/TextForeColor instead");
+            }
+
+            base.ForeColor = value;
+        }
     }
 
     [Editor]
@@ -222,15 +240,11 @@ public class StylableTextBox : TextBox
     {
         if (IsHintActive)
         {
-#pragma warning disable CS0618 //Obsolete
             ForeColor = HintForeColor;
-#pragma warning restore CS0618 //Obsolete
         }
         else
         {
-#pragma warning disable CS0618 //Obsolete
             ForeColor = TextForeColor;
-#pragma warning restore CS0618 //Obsolete
         }
     }
 }

--- a/StylableWinFormsControls/StylableWinFormsControls/InternalUseOnlyAttribute.cs
+++ b/StylableWinFormsControls/StylableWinFormsControls/InternalUseOnlyAttribute.cs
@@ -1,0 +1,23 @@
+
+namespace StylableWinFormsControls
+{
+    /// <summary>
+    /// marks a method or property as internal only. this can be used when inherited properties should not be used from outside callers
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+    public sealed class InternalUseOnlyAttribute : Attribute
+    {
+        /// <summary>
+        /// the description why this should not be used
+        /// </summary>
+        public string Description { get; }
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="description">the description why this should not be used</param>
+        public InternalUseOnlyAttribute(string description)
+        {
+            Description = description;
+        }
+    }
+}


### PR DESCRIPTION
## About this PR
prevent accidental use of parent setters as described in #53

## Checklist
(Please strikethrough all not applicable points instead of removing them)

- [x] I have added a suitable example in the example application
- [ ] ~~I have updated the documentation in the readme~~
